### PR TITLE
update testnet shred version to 2279

### DIFF
--- a/src/testnet.md
+++ b/src/testnet.md
@@ -36,7 +36,7 @@ Douro Labs currently runs a public RPC endpoint for users to interact with Testn
 - Entrypoints: `["entrypoint1.testnet.fogo.io:8001", "entrypoint2.testnet.fogo.io:8001", "entrypoint3.testnet.fogo.io:8001", "entrypoint1.testnet.fogo.io:9010", "entrypoint2.testnet.fogo.io:9010", "entrypoint3.testnet.fogo.io:9010"]`
 
 - Genesis hash: `9GGSFo95raqzZxWqKM5tGYvJp5iv4Dm565S4r8h5PEu9`
-- Shred version: `12481`
+- Shred version: `2279`
 
 ## Example Configuration
 


### PR DESCRIPTION
shred version changed after testnet restart today
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dourolabs/fogo-docs/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->